### PR TITLE
Enhancement of the CommonViewPeriod 

### DIFF
--- a/cggtts/src/cv/calendar.rs
+++ b/cggtts/src/cv/calendar.rs
@@ -8,6 +8,8 @@ pub struct CommonViewCalendar {
     /// Deploy time is the [Epoch] at which
     /// the first [CommonViewPeriod] was launched
     start_time: Epoch,
+    /// Indicates whether this is the first tracking in a MJD.
+    is_t0: bool,
     /// [CommonViewPeriod] specification
     period: CommonViewPeriod,
 }
@@ -25,8 +27,10 @@ impl CommonViewCalendar {
     /// to your [CommonViewPeriod] specifications.
     pub fn now(period: CommonViewPeriod) -> Result<Self, HifitimeError> {
         let now = Self::now_utc()?;
+        let (start_time, is_t0) = period.next_period_start(now);
         Ok(Self {
-            start_time: period.next_period_start(now),
+            start_time,
+            is_t0,
             period,
         })
     }
@@ -39,8 +43,10 @@ impl CommonViewCalendar {
         period: CommonViewPeriod,
     ) -> Result<Self, HifitimeError> {
         let now = Self::now_utc()?;
+        let (start_time, is_t0) = period.next_period_start(now + postponing);
         Ok(Self {
-            start_time: period.next_period_start(now + postponing),
+            start_time,
+            is_t0,
             period,
         })
     }

--- a/cggtts/src/cv/period.rs
+++ b/cggtts/src/cv/period.rs
@@ -50,6 +50,14 @@ impl CommonViewPeriod {
     /// Offset of first track for any given MJD, expressed in nanoseconds
     /// within that day.
     fn first_track_offset_nanos(&self, mjd: u32) -> i128 {
+        // if not bimp period, return 0
+        if self.setup_duration != Duration::from_seconds(BIPM_SETUP_DURATION_SECONDS as f64)
+            || self.tracking_duration
+            != Duration::from_seconds(BIPM_TRACKING_DURATION_SECONDS as f64)
+        {
+            return 0i128;
+        }
+
         let tracking_nanos = self.total_period().total_nanoseconds();
 
         let mjd_difference = REFERENCE_MJD as i128 - mjd as i128;

--- a/cggtts/src/cv/period.rs
+++ b/cggtts/src/cv/period.rs
@@ -53,7 +53,7 @@ impl CommonViewPeriod {
         // if not bimp period, return 0
         if self.setup_duration != Duration::from_seconds(BIPM_SETUP_DURATION_SECONDS as f64)
             || self.tracking_duration
-            != Duration::from_seconds(BIPM_TRACKING_DURATION_SECONDS as f64)
+                != Duration::from_seconds(BIPM_TRACKING_DURATION_SECONDS as f64)
         {
             return 0i128;
         }
@@ -76,11 +76,12 @@ impl CommonViewPeriod {
         }
     }
 
-    /// Returns date and time of next [CommonViewPeriod]
-    /// expressed as an [Epoch]. `now` may be any [Epoch]
+    /// Returns the date and time of the next [CommonViewPeriod] expressed as an [Epoch]
+    /// and a boolean indicating whether the next [CommonViewPeriod] is `t0`.
+    /// `now` may be any [Epoch]
     /// but is usually `now()` when actively tracking.
     /// Although CGGTTS uses UTC strictly, we accept any timescale here.
-    pub fn next_period_start(&self, now: Epoch) -> Epoch {
+    pub fn next_period_start(&self, now: Epoch) -> (Epoch, bool) {
         let total_period = self.total_period();
         let total_period_nanos = total_period.total_nanoseconds();
 
@@ -99,7 +100,7 @@ impl CommonViewPeriod {
 
         if today_offset_nanos < today_t0_offset_nanos {
             // still within first track
-            today_t0_utc
+            (today_t0_utc, true)
         } else {
             let ith_period = (((now_utc - today_t0_utc).total_nanoseconds() as f64)
                 / total_period_nanos as f64)
@@ -110,12 +111,18 @@ impl CommonViewPeriod {
             if ith_period >= number_periods_per_day {
                 let tomorrow_t0_offset_nanos = self.first_track_offset_nanos(mjd_utc + 1);
 
-                Epoch::from_mjd_utc((mjd_utc + 1) as f64)
-                    + tomorrow_t0_offset_nanos as f64 * Unit::Nanosecond
+                (
+                    Epoch::from_mjd_utc((mjd_utc + 1) as f64)
+                        + tomorrow_t0_offset_nanos as f64 * Unit::Nanosecond,
+                    false,
+                )
             } else {
-                today_midnight_utc
-                    + today_t0_offset_nanos as f64 * Unit::Nanosecond
-                    + (ith_period * total_period_nanos) as f64 * Unit::Nanosecond
+                (
+                    today_midnight_utc
+                        + today_t0_offset_nanos as f64 * Unit::Nanosecond
+                        + (ith_period * total_period_nanos) as f64 * Unit::Nanosecond,
+                    false,
+                )
             }
         }
     }
@@ -125,7 +132,8 @@ impl CommonViewPeriod {
     /// but is usually `now()` when actively tracking.
     /// Although CGGTTS uses UTC strictly, we accept any timescale here.
     pub fn time_to_next_period(&self, now: Epoch) -> Duration {
-        self.next_period_start(now) - now
+        let (next_period_start, _) = self.next_period_start(now);
+        next_period_start - now
     }
 
     /// Returns a new [CommonViewPeriod] with desired setup [Duration]
@@ -189,6 +197,9 @@ mod test {
     #[test]
     fn cv_next_period_start() {
         let cv = CommonViewPeriod::bipm_common_view_period();
+
+        let (mjd_59025_last_t, _) = CommonViewPeriod::bipm_common_view_period()
+            .next_period_start(Epoch::from_mjd_utc(59026.0));
 
         for (now, expected) in vec![
             // reference MJD
@@ -305,8 +316,7 @@ mod test {
                 Epoch::from_mjd_utc(59025.0)
                     + 23.0 * Unit::Hour
                     + (50.0 * 60.0 + 10.0) * Unit::Second,
-                CommonViewPeriod::bipm_common_view_period()
-                    .next_period_start(Epoch::from_mjd_utc(59026.0)),
+                mjd_59025_last_t,
             ),
             // // MJD = 59_025 N-1 +10s => MJD 59_026 T0
             (
@@ -316,7 +326,7 @@ mod test {
                 Epoch::from_mjd_utc(59026.0) + (2.0 * 60.0) * Unit::Second,
             ),
         ] {
-            let next_start = cv.next_period_start(now);
+            let (next_start, _) = cv.next_period_start(now);
             let error_nanos = (next_start - expected).abs().total_nanoseconds();
             assert!(
                 error_nanos < 1,


### PR DESCRIPTION
## 1. CommonViewPeriod::first_track_offset_nanos() returns zero if it is not a bipm_common_view_period.

The 4-minute offset is only applicable to BIPM; for custom periods, `0` might be more reasonable.
```
# CGGTTS-Version 2E  2.1
These tracking epochs are offset by 4 minutes each day; this offset was originally
fixed in order to stay aligned with the sidereal period of the GPS constellation and to follow each
day the same common-view comparison schedule. Even if the daily repeatability is not needed
any more and is not valid for the constellations other than GPS, it has been decided to keep the
same tracking schedule in order to assure the full compatibility with the previous version of the
CGGTTS.
```

## 2. CommonViewPeriod::next_period_start() adds a return value to indicate whether the next CommonViewPeriod is t0.

After calling `CommonViewPeriod::next_period_start()`, we should know if it's t0. Without this information, we won't know how to preserve the measurement data during the overlap period.  
If it's t0, we should start recording the measurement count in the tracker and do nothing else. On the next t (t_89), we remove the recorded count from the tracker.  
NOTE: This logic only works when there is an overlap period spanning days(BIPM period). If there is no overlap period, the tracker should always be reset before starting a new tracking.
```
                        │                                         │       
                        ├──────────────► T0     ◄─────────────────┼       
                        │                                         │       
                                                                          
                   MJD 59026(T0)     MJD 59025(T89)                       
  │                     │                 │                       │       
 ─┼─────────────────────┼─────────────────┼───────────────────────┼───────
  │                     │                 │                       │       
23:50                00:02              00:03                  00:18      
                                                                          
  │                                       │                               
  ├──────────────►  T89     ◄─────────────┤                               
  │                                       │                               
                                                                          
```
